### PR TITLE
Collects coverage from ts and tsx files

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -4,7 +4,7 @@ const config = require('../utils/configure')();
 module.exports = {
     collectCoverage: true,
     collectCoverageFrom: [
-        '**/*.{js,jsx}',
+        '**/*.{js,ts,jsx,tsx}',
         '!**/*.config.js',
         '!**/node_modules/**',
         '!**/vendor/**',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuel/uniformly",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Spend less time setting up projects and more time building them",
   "files": [
     "utils",


### PR DESCRIPTION
Fixes the default jest configuration to include `ts` and `tsx` files in the "collectCoverageFrom" configuration, so that TypeScript files are included in coverage reports.