### PR TITLE
Adds support for Jest setup with default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 3.0.4 (2020-07-09)
+### Added
+ - You can now specify a value for `setupFiles` in the default Jest config. This means it is no longer necessary to specify a completely custom config if there are setup tasks before your tests.
+
 ## 3.0.0 (2019-12-24)
 ### Fixed
  - Ensures exit code bubbles up, this should resolve a number of issues when running inside of CI environments.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ If you need more control over what's happening, create a `.uniformlyrc` file wit
     },
     "jest": {
         "roots": [ "custom/jest/root" ],
-        "config": "/path/to/jest.config.js"
+        "config": "/path/to/jest.config.js",
+        "setupFiles": ["<rootDir>/setupTests.js"]
     },
     "prettier": {
         "config": "/path/to/prettier.config.js"

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -14,4 +14,5 @@ module.exports = {
     },
     roots: config.jest.roots,
     rootDir: process.cwd(),
+    setupFiles: config.jest.setupFiles,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuel/uniformly",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Spend less time setting up projects and more time building them",
   "files": [
     "utils",

--- a/utils/configure.js
+++ b/utils/configure.js
@@ -29,7 +29,7 @@ function resolveLibraryPrefix() {
     return 'default';
 }
 
-module.exports = function() {
+module.exports = function () {
     if (!config) {
         const framework = resolveLibraryPrefix();
 
@@ -43,6 +43,7 @@ module.exports = function() {
             jest: {
                 roots: ['src/'],
                 config: resolveConfigFile('jest.config.js'),
+                setupFiles: [],
             },
             prettier: {
                 config: resolveConfigFile('prettier.config.js'),


### PR DESCRIPTION
This resolves #8, adding support for using Jest setup files _without_ requiring the Jest config file to be completely overwritten with a custom one. This provides support for scenarios such as using `dotenv` to load environment variables for test cases and other test setup scenarios that were otherwise unnecessarily awkward. 